### PR TITLE
Update use-dmarc-to-validate-email.md

### DIFF
--- a/SecurityCompliance/use-dmarc-to-validate-email.md
+++ b/SecurityCompliance/use-dmarc-to-validate-email.md
@@ -218,7 +218,8 @@ contoso.com     3600   IN  MX  10 contoso-com.mail.protection.outlook.com
 
 ```
 
-All, or most, email will first be routed to mail.contoso.com since it's the primary MX, and then mail will get routed to EOP. In some cases, you might not even list EOP as an MX record at all and simply hook up connectors to route your email. EOP must be the first entry in your domain's MX records in order for DMARC failures to be enforced for your domain.
+All, or most, email will first be routed to mail.contoso.com since it's the primary MX, and then mail will get routed to EOP. In some cases, you might not even list EOP as an MX record at all and simply hook up connectors to route your email. EOP does not have to be the first entry for DMARC validation to be done. It just ensures the validation, as we cannot be certain that all on-premise/non-O365 servers will do DMARC checks.  DMARC is eligible to be enforced for a customer’s domain (not server) when you set up the DMARC TXT record, but it is up to the receiving server to actually do the enforcement.  If you set up EOP as the receiving server, then EOP does the DMARC enforcement.
+
   
 ## For more information
 <a name="sectionSection8"> </a>


### PR DESCRIPTION
Please replace "EOP must be the first entry in your domain's MX records in order for DMARC failures to be enforced for your domain." with "EOP does not have to be the first entry for DMARC validation to be done. It just ensures the validation, as we cannot be certain that all on-premise/non-O365 servers will do DMARC checks.  DMARC is eligible to be enforced for a customer’s domain (not server) when you set up the DMARC TXT record, but it is up to the receiving server to actually do the enforcement.  If you set up EOP as the receiving server, then EOP does the DMARC enforcement.", because the first statement is incorrect. Edit approved by SPM Murali Natarajan. Thanks!

Please edit the added text as appropriate for DOCS style.