### PR TITLE
delete-items-in-the-recoverable-items-folder-of-mailboxes-on-hold.md

### DIFF
--- a/SecurityCompliance/delete-items-in-the-recoverable-items-folder-of-mailboxes-on-hold.md
+++ b/SecurityCompliance/delete-items-in-the-recoverable-items-folder-of-mailboxes-on-hold.md
@@ -106,7 +106,7 @@ Additionally, you need to get the mailbox client access settings so you can temp
 
    If the user's archive mailbox is enabled, run the following command to get the size and total number of items in folders and subfolders in the Recoverable Items folder in their archive mailbox. 
 
-    ```
+    ```s
     Get-MailboxFolderStatistics <username> -FolderScope RecoverableItems -Archive | FL Name,FolderAndSubfolderSize,ItemsInFolderAndSubfolders
     ```
 


### PR DESCRIPTION
After removing any kind of Hold from the mailbox, the DelayHoldApplied attribute will be set to True, this is a safety net in case Admins accidentally remove Litigation hold from mailboxes. As long as it's set to True the mailbox will still be considered under Hold for 30 days. 
To remove this run the following cmdlet: 
Set-mailbox -identity user@contoso.com -RemoveDelayHoldApplied