### PR TITLE
Update use-explorer-in-security-and-compliance.md

### DIFF
--- a/SecurityCompliance/use-explorer-in-security-and-compliance.md
+++ b/SecurityCompliance/use-explorer-in-security-and-compliance.md
@@ -26,7 +26,7 @@ To use Explorer, in the Security &amp; Compliance Center, go to **Threat managem
       
 ## Explorer overview
 
-Explorer displays information about suspected malware in email and files in Office 365, as well as other security threats and risks to your organization. When you first open Explorer, the default view shows malware detections from antivirus. Explorer can also show security protection features in Office 365, including [Safe Links](atp-safe-links.md) and [Safe Attachments](atp-safe-attachments.md).
+Explorer displays information about suspected malware in email and files in Office 365, as well as other security threats and risks to your organization. When you first open Explorer, the default view shows malware detections from antivirus for the past 7 days. Explorer can also show security protection features in Office 365, including [Safe Links](atp-safe-links.md) and [Safe Attachments](atp-safe-attachments.md) and can be modified to show data for the past 30 days.
   
 ![Explorer shows info about top malware and targeted users](media/8e8c1582-d6f4-4521-8591-686a1cb01f7e.png)
   


### PR DESCRIPTION
Added information about Threat Explorer showing 7 days when opened, with 30 days available for querying.

I am not sure if this would also be a good place to note that trial subscriptions of Threat Intelligence will only have 7 days of historical data, not 30.