### PR TITLE
Added note about DisallowInfectedFileDownload Flag

### DIFF
--- a/SecurityCompliance/virus-detection-in-spo.md
+++ b/SecurityCompliance/virus-detection-in-spo.md
@@ -3,7 +3,7 @@ title: "Virus detection in SharePoint Online"
 ms.author: krowley
 author: kccross
 manager: laurawi
-ms.date: 4/17/2018
+ms.date: 01/14/2019
 ms.audience: Admin
 ms.topic: reference
 ms.service: o365-administration
@@ -43,10 +43,10 @@ Here's what happens:
   
 1. A user opens a web browser and tries to download an infected file from SharePoint Online.
     
-2. The user is given a warning that a virus has been detected, and is given the option to download the file and attempt to clean it using their own virus software.
+2. The user is given a warning that a virus has been detected. The user is given the option to download the file and attempt to clean it using their own virus software.
 
 > [!NOTE]
-> Usign the Set-SPOTenant cmdlet you can set **DisallowInfectedFileDownload** flag to not allow the users to download the file even from the anti-virus warning window. See [DisallowInfectedFileDownload] (https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/Set-SPOTenant).
+> You can use the Set-SPOTenant cmdlet with the **DisallowInfectedFileDownload** parameter to not allow users to download a detected file, even in the anti-virus warning window. See [DisallowInfectedFileDownload] (https://docs.microsoft.com/powershell/module/sharepoint-online/Set-SPOTenant).
     
 ## What happens when the OneDrive sync client tries to sync an infected file?
 

--- a/SecurityCompliance/virus-detection-in-spo.md
+++ b/SecurityCompliance/virus-detection-in-spo.md
@@ -44,6 +44,9 @@ Here's what happens:
 1. A user opens a web browser and tries to download an infected file from SharePoint Online.
     
 2. The user is given a warning that a virus has been detected, and is given the option to download the file and attempt to clean it using their own virus software.
+
+> [!NOTE]
+> Usign the Set-SPOTenant cmdlet you can set **DisallowInfectedFileDownload** flag to not allow the users to download the file even from the anti-virus warning window. See [DisallowInfectedFileDownload] (https://docs.microsoft.com/en-us/powershell/module/sharepoint-online/Set-SPOTenant).
     
 ## What happens when the OneDrive sync client tries to sync an infected file?
 


### PR DESCRIPTION
Article tells that the user can still download the infected file. Since there was no mention about the DisallowInfectedFileDownload on this page, added the note.