### PR TITLE
Added Disable and Enable Timerjob to the sample

### DIFF
--- a/SecurityCompliance/gdpr-for-sharepoint-server.md
+++ b/SecurityCompliance/gdpr-for-sharepoint-server.md
@@ -254,8 +254,10 @@ To delete all usage records associated with deleted documents: 
 
     ```powershell
     $tj = Get-SPTimerJob -Type Microsoft.Office.Server.Search.Analytics.UsageAnalyticsJobDefinition 
+    $tj.DisableTimerjobSchedule()
     $tj.StopAnalysis() 
     $tj.ClearAnalysis() 
+    $tj.EnableTimerjobSchedule()
     ```
 
 4.  Wait for the analysis to start again (might take up to 24 hours). 


### PR DESCRIPTION
When trying to execute the sample, SharePoint 2016 complains that the timerjob should first be disabled before the StopAnalysis and ClearAnalysis commands are being run. Afterwards it requires running EnableTimerJobsSchedule to set the schedule back in place. I've updated the sample to include the disabling and enabling so the sample works.