### PR TITLE
Clarify where DKIM CNAME records are created

### DIFF
--- a/SecurityCompliance/use-dkim-to-validate-outbound-email.md
+++ b/SecurityCompliance/use-dkim-to-validate-outbound-email.md
@@ -77,7 +77,7 @@ To configure DKIM, you will complete these steps:
 ### Publish two CNAME records for your custom domain in DNS
 <a name="Publish2CNAME"> </a>
 
-For each domain for which you want to add a DKIM signature in DNS, you need to publish two CNAME records. A CNAME record is used by DNS to specify that the canonical name of a domain is an alias for another domain name. 
+For each domain for which you want to add a DKIM signature in DNS, you need to publish two CNAME records. A CNAME record is used by DNS to specify that the canonical name of a domain is an alias for another domain name. The CNAME records should be created on the publicly available DNS servers for your customized domains. The CNAME records in your DNS will point to already created A records that exist in DNS on the Microsoft DNS servers for Office 365.
   
  Office 365 performs automatic key rotation using the two records that you establish. If you have provisioned custom domains in addition to the initial domain in Office 365, you must publish two CNAME records for each additional domain. So, if you have two domains, you must publish two additional CNAME records, and so on.
   


### PR DESCRIPTION
Due to Support requests for multiple customers in the GCC High environment, I'm updating this article to make it more clear that the CNAME records for DKIM are created on the customer's DNS servers and point to automatically setup DNS records on the Microsoft servers.