### PR TITLE
Update customize-a-built-in-sensitive-information-type.md

### DIFF
--- a/SecurityCompliance/customize-a-built-in-sensitive-information-type.md
+++ b/SecurityCompliance/customize-a-built-in-sensitive-information-type.md
@@ -24,7 +24,7 @@ You can take this example and apply it to other built-in sensitive information t
   
 ## Export the XML file of the current rules
 
-To export the XML, you need to [connect to the Security and Compliance Center via Remote PowerShell.](https://go.microsoft.com/fwlink/?linkid=799771).
+To export the XML, you need to [connect to the Security and Compliance Center via Remote PowerShell.](https://docs.microsoft.com/en-us/powershell/exchange/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell?view=exchange-ps).
   
 1. In the PowerShell, type the following to display your organization's rules on screen. If you haven't created your own, you'll only see the default, built-in rules, labeled "Microsoft Rule Package."
     

--- a/SecurityCompliance/customize-a-built-in-sensitive-information-type.md
+++ b/SecurityCompliance/customize-a-built-in-sensitive-information-type.md
@@ -3,7 +3,7 @@ title: "Customize a built-in sensitive information type"
 ms.author: deniseb
 author: denisebmsft
 manager: laurawi
-ms.date: 6/25/2018
+ms.date: 04/03/2019
 ms.audience: Admin
 ms.topic: article
 ms.service: O365-seccomp
@@ -24,7 +24,7 @@ You can take this example and apply it to other built-in sensitive information t
   
 ## Export the XML file of the current rules
 
-To export the XML, you need to [connect to the Security and Compliance Center via Remote PowerShell.](https://docs.microsoft.com/en-us/powershell/exchange/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell?view=exchange-ps).
+To export the XML, you need to [connect to the Security and Compliance Center via Remote PowerShell.](https://docs.microsoft.com/powershell/exchange/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell?view=exchange-ps).
   
 1. In the PowerShell, type the following to display your organization's rules on screen. If you haven't created your own, you'll only see the default, built-in rules, labeled "Microsoft Rule Package."
     


### PR DESCRIPTION
The link for connecting to Security and Compliance Center powershell was wrong.  I updated the link to:https://docs.microsoft.com/en-us/powershell/exchange/office-365-scc/connect-to-scc-powershell/connect-to-scc-powershell?view=exchange-ps

Under the section:
## Export the XML file of the current rules