### PR TITLE
parameter name wasn't completely accurate

### DIFF
--- a/SecurityCompliance/set-up-new-message-encryption-capabilities.md
+++ b/SecurityCompliance/set-up-new-message-encryption-capabilities.md
@@ -65,7 +65,7 @@ You can verify that your Office 365 tenant is properly configured to use the new
 
 2. Run the Get-IRMConfiguration cmdlet.
 
-     You should see a value of $True for the AzureRMSEnabled parameter, which indicates that OME is configured in your tenant. If it is not, use Set-IRMConfiguration to set the value of AzureRMSEnabled to $True to enable OME.
+     You should see a value of $True for the AzureRMSLicensingEnabled parameter, which indicates that OME is configured in your tenant. If it is not, use Set-IRMConfiguration to set the value of AzureRMSLicensingEnabled to $True to enable OME.
 
 3. Run the Test-IRMConfiguration cmdlet using the following syntax:
 


### PR DESCRIPTION
parameter name wasn't completely accurate