### PR TITLE
Update detect-and-remediate-illicit-consent-grants.md

### DIFF
--- a/SecurityCompliance/detect-and-remediate-illicit-consent-grants.md
+++ b/SecurityCompliance/detect-and-remediate-illicit-consent-grants.md
@@ -30,7 +30,11 @@ You need to search the Office 365 **audit log** to find signs, also called Indic
 3. Create a search (all activities and all users) and filter the results for Consent to application, and Add OAuth2PermissionGrant.
 4. Examine the Extended Properties and check to see if IsAdminContent is set to True.
 
-
+> [!NOTE]
+>  
+   - It can take up to 30 minutes or up to 24 hours after an event occurs for the corresponding audit log entry to be displayed in the search results.
+   - The length of time that an audit record is retained and searchable in the audit log depends on your Office 365 subscription, and specifically the type of the license that is assigned to a specific user. For more information, see [Audit log](search-the-audit-log-in-security-and-compliance.md).
+      
 If this value is true, it indicates that someone with Global Administrator access may have granted broad access to data. If this is unexpected, take steps to [confirm an attack](detect-and-remediate-illicit-consent-grants.md#confirmattack).
 
 <a name="confirmattack"> </a>


### PR DESCRIPTION
#559 
* Auditlog consent application still works, for this to show as a result in audit log user should consider/check the following

* The length of time that an audit record is retained and searchable in the audit log depends on your Office 365 subscription, and specifically the type of the license that is assigned to a specific user.

* It can take up to 30 minutes or up to 24 hours after an event occurs for the corresponding audit log entry to be displayed in the search results. 

See article for more information about Audit log
https://docs.microsoft.com/en-us/office365/securitycompliance/search-the-audit-log-in-security-and-compliance

References:
Defending Against Illicit Consent Grants
https://blogs.technet.microsoft.com/office365security/defending-against-illicit-consent-grants/

Managing user consent for applications using Office 365 APIs
https://blogs.msdn.microsoft.com/exchangedev/2014/06/05/managing-user-consent-for-applications-using-office-365-apis/

Email Phishing Protection Guide – Part 17: Control Application Consent Registrations in Microsoft Office 365 and Azure
https://blogs.technet.microsoft.com/cloudready/2018/11/21/part-17-control-application-consent-registrations-in-microsoft-office-365-and-azure/ 