### PR TITLE
Update dynamic-delivery-and-previewing.md

### DIFF
--- a/SecurityCompliance/dynamic-delivery-and-previewing.md
+++ b/SecurityCompliance/dynamic-delivery-and-previewing.md
@@ -76,4 +76,4 @@ There are certain scenarios in which Dynamic Delivery is not supported. These in
 
 - Messages encrypted with [Secure/Multipurpose Internet Mail Extensions (S/MIME)](s-mime-for-message-signing-and-encryption.md))
 
-In cases where Dynamic Delivery is not supported, ATP Safe Attachments will not scan email messages. However, delivering the emails with attachment depending on how your [ATP Safe Links policies](set-up-atp-safe-links-policies.md) are configured, URLs in email messages (and Office files) will be checked.
+- In cases where Dynamic Delivery is not supported, ATP Safe Attachments will not scan email messages. However, delivering email messages with attachments that contain URLs will be checked, depending on how your [ATP Safe Links policies](set-up-atp-safe-links-policies.md) are configured. In these cases, URLs in email messages and Office files are checked.

--- a/SecurityCompliance/dynamic-delivery-and-previewing.md
+++ b/SecurityCompliance/dynamic-delivery-and-previewing.md
@@ -76,4 +76,4 @@ There are certain scenarios in which Dynamic Delivery is not supported. These in
 
 - Messages encrypted with [Secure/Multipurpose Internet Mail Extensions (S/MIME)](s-mime-for-message-signing-and-encryption.md))
 
-In cases where Dynamic Delivery is not supported, ATP Safe Attachments will not scan email messages. However, depending on how your [ATP Safe Links policies](set-up-atp-safe-links-policies.md) are configured, URLs in email messages (and Office files) will be checked.
+In cases where Dynamic Delivery is not supported, ATP Safe Attachments will not scan email messages. However, delivering the emails with attachment depending on how your [ATP Safe Links policies](set-up-atp-safe-links-policies.md) are configured, URLs in email messages (and Office files) will be checked.

--- a/SecurityCompliance/dynamic-delivery-and-previewing.md
+++ b/SecurityCompliance/dynamic-delivery-and-previewing.md
@@ -3,7 +3,7 @@ title: "Dynamic Delivery and previewing with Office 365 ATP Safe Attachments"
 ms.author: deniseb
 author: denisebmsft
 manager: laurawi
-ms.date: 03/12/2019
+ms.date: 04/19/2019
 ms.audience: Admin
 ms.topic: overview
 ms.service: O365-seccomp


### PR DESCRIPTION
#561 
Action Taken:
added "delivering the emails with attachment".. depending on how your [ATP Safe Links policies]..

* S/MIME uses encryption/digital signatures for the email attachment, since Dynamic Delivery do not support this ATP Safe Attachments will not scan email messages that has S/MIME, so S/MIME attachment will still be deliver but in a standard process , it will depend with the policy created by the user or admins in the organization.

References: https://docs.microsoft.com/en-us/previous-versions/tn-archive/aa995740(v=exchg.65)
https://docs.microsoft.com/en-us/office365/securitycompliance/s-mime-for-message-signing-and-encryption 