### PR TITLE
Update partially-indexed-items-in-content-search.md

### DIFF
--- a/SecurityCompliance/partially-indexed-items-in-content-search.md
+++ b/SecurityCompliance/partially-indexed-items-in-content-search.md
@@ -73,7 +73,7 @@ Your organization might be required to identify and perform additional analysis 
   
 Keep the following in mind about partially indexed items:
   
-- When you run a content search, the total number and size of partially indexed Exchange items (returned by the search query) are displayed in search statistics in the details pane, as labeled as **Indexed items**. Note that statistics about partially indexed items displayed in the detail pane don't include partially indexed items in SharePoint or OneDrive.
+- When you run a content search, the total number and size of partially indexed Exchange items (returned by the search query) are displayed in search statistics in the details pane, and labeled as **Indexed items**. Note that statistics about partially indexed items displayed in the details pane don't include partially indexed items in SharePoint or OneDrive.
     
 - If the search that you're exporting results from was a search of specific content locations or all content locations in your organization, only the unindexed items from content locations that contain items that match the search criteria will be exported. In other words, if no search results are found in a mailbox or site, then any unindexed items in that mailbox or site won't be exported. The reason for this is that exporting partially indexed items from lots of locations in the organization might increase the likelihood of export errors and increase the time it takes to export and download the search results.
     

--- a/SecurityCompliance/partially-indexed-items-in-content-search.md
+++ b/SecurityCompliance/partially-indexed-items-in-content-search.md
@@ -73,7 +73,7 @@ Your organization might be required to identify and perform additional analysis 
   
 Keep the following in mind about partially indexed items:
   
-- When you run a content search, the total number and size of partially indexed Exchange items (returned by the search query) are displayed in search statistics in the details pane, as labeled as **Unindexed items**. Note that statistics about partially indexed items displayed in the detail pane don't include partially indexed items in SharePoint or OneDrive.
+- When you run a content search, the total number and size of partially indexed Exchange items (returned by the search query) are displayed in search statistics in the details pane, as labeled as **Indexed items**. Note that statistics about partially indexed items displayed in the detail pane don't include partially indexed items in SharePoint or OneDrive.
     
 - If the search that you're exporting results from was a search of specific content locations or all content locations in your organization, only the unindexed items from content locations that contain items that match the search criteria will be exported. In other words, if no search results are found in a mailbox or site, then any unindexed items in that mailbox or site won't be exported. The reason for this is that exporting partially indexed items from lots of locations in the organization might increase the likelihood of export errors and increase the time it takes to export and download the search results.
     


### PR DESCRIPTION
Below statement seems to be contradicting referring the RFC # 1043311

When you run a content search, the total number and size of partially indexed Exchange items (returned by the search query) are displayed in search statistics in the details pane, as labeled as Unindexed items.

Copying comments from the RFC :

For exchange items, partially indexed items should be count in the indexed items.

For SharePoint items, partially indexed items could be count in both indexed and unindexed counts. But we will only download one copy of it.
