### PR TITLE
Update manage-mail-users-in-eop.md

### DIFF
--- a/SecurityCompliance/eop/manage-mail-users-in-eop.md
+++ b/SecurityCompliance/eop/manage-mail-users-in-eop.md
@@ -59,11 +59,9 @@ Get the necessary permissions and prepare for directory synchronization, as desc
     > [!IMPORTANT]
     > When you finish the Azure Active Directory Sync Tool Configuration Wizard, the **MSOL_AD_SYNC** account is created in your Active Directory forest. This account is used to read and synchronize your on-premises Active Directory information. In order for directory synchronization to work correctly, make sure that TCP 443 on your local directory synchronization server is open. 
   
-4. Activate synced users, as described in [Activate synced users](http://go.microsoft.com/fwlink/p/?LinkId=308913).
+  4. Manage directory synchronization, as described in [Manage directory synchronization](http://go.microsoft.com/fwlink/p/?LinkId=308915).
     
-5. Manage directory synchronization, as described in [Manage directory synchronization](http://go.microsoft.com/fwlink/p/?LinkId=308915).
-    
-6. Verify that EOP is synchronizing correctly. In the EAC, go to **Recipients** \> **Contacts** and view that the list of users was correctly synchronized from your on-premises environment. 
+  5. Verify that EOP is synchronizing correctly. In the EAC, go to **Recipients** \> **Contacts** and view that the list of users was correctly synchronized from your on-premises environment. 
     
 ## Use the EAC to manage mail users
 


### PR DESCRIPTION
removed the activation part as the mail users show up in Exchange online as soon as the synchornization is complete and there is no activation needed.