### PR TITLE
Update set-up-atp-safe-links-policies.md

### DIFF
--- a/SecurityCompliance/set-up-atp-safe-links-policies.md
+++ b/SecurityCompliance/set-up-atp-safe-links-policies.md
@@ -96,7 +96,7 @@ After you have reviewed (or edited) the default ATP Safe Links policy that appli
     
   - Select **Apply Safe Links to messages sent within the organization** if you would like to enable Safe Links for messages sent between users within your organization (recommended).
     
-  - Select **Do not allow user to click through to original URL**.
+  - Select **Do not allow user to click through to original URL** if you do not wish the individual users to override a *scan in progress* or *URL blocked* notification pages.
     
   - (This is optional) In the **Do not rewrite the following URLs** section, specify one or more URLs that are considered to be safe for your organization. (See [Set up a custom "Do not rewrite" URLs list using ATP Safe Links](set-up-a-custom-do-not-rewrite-urls-list-with-atp.md))
     


### PR DESCRIPTION
Clarifying reasons about why "Do not allow users to click through to original URL" option is suggested.