### PR TITLE
Adding 1TB/20 Aux Archive Limits to article

### DIFF
--- a/SecurityCompliance/unlimited-archiving.md
+++ b/SecurityCompliance/unlimited-archiving.md
@@ -21,7 +21,7 @@ description: "Learn about auto-expanding archiving in Office 365, which provides
 
 In Office 365, archive mailboxes provide users with additional mailbox storage space. After a user's archive mailbox is enabled, up to 100 GB of additional storage is available. In the past, when the 100 GB storage quota was reached, organizations had to contact Microsoft to request additional storage space for an archive mailbox. That's no longer the case.
 
-The unlimited archiving feature in Office 365 (called *auto-expanding archiving*) provides upto 1 TB of additional storage in archive mailboxes. Now, when the storage quota in the archive mailbox is reached, Office 365 automatically increases the size of the archive, which means that users won't run out of mailbox storage space and administrators won't have to request additional storage for archive mailboxes.
+The unlimited archiving feature in Office 365 (called *auto-expanding archiving*) provides up to 1 TB of additional storage in archive mailboxes. When the storage quota in the archive mailbox is reached, Office 365 automatically increases the size of the archive, which means that users won't run out of mailbox storage space and administrators won't have to request additional storage for archive mailboxes.
   
 For step-by-step instructions for turning on auto-expanding archiving, see [Enable unlimited archiving in Office 365](enable-unlimited-archiving.md).
   
@@ -30,7 +30,7 @@ For step-by-step instructions for turning on auto-expanding archiving, see [Enab
   
 ## How auto-expanding archiving works
 
-As previously explained, additional mailbox storage space is created when a user's archive mailbox is enabled. When auto-expanding archiving is enabled, Office 365 periodically checks the size of the archive mailbox. When an archive mailbox gets close to its storage limit, Office 365 automatically creates additional storage space for the archive commonly referred to as the auxiliary archive. If the user runs out of this additional storage space, Office 365 will add upto 20 auxiliary archives to provide addtional storage. This process happens automatically, which means administrators don't have to request additional archive storage or manage auto-expanding archiving. 
+As previously explained, additional mailbox storage space is created when a user's archive mailbox is enabled. When auto-expanding archiving is enabled, Office 365 periodically checks the size of the archive mailbox. When an archive mailbox gets close to its storage limit, Office 365 automatically creates additional storage space for the archive mailbox. This additional space is called an *auxiliary archive*. If the user runs out of storage space in an auxiliary archive, Office 365 will automatically add a new auxiliary archive. Office 365 will add a maximum of 20 auxiliary archives for a total of 1 TB of addtional storage. This process happens automatically, which means administrators don't have to manage auto-expanding archiving. 
   
 Here's a quick overview of the process.
   
@@ -38,14 +38,15 @@ Here's a quick overview of the process.
   
 1. Archiving is enabled for a user mailbox or a shared mailbox. An archive mailbox with 100 GB of storage space is created, and the warning quota for the archive mailbox is set to 90 GB.
     
-2. An administrator enables auto-expanding archiving for the mailbox. Then, when the archive mailbox (including the Recoverable Items folder) reaches 90 GB, it's converted to an auto-expanding archive, and Office 365 adds storage space to the archive. Note that it can take up to 30 days for the additional storage space to be provisioned.
+2. An administrator enables auto-expanding archiving for the mailbox. When the archive mailbox (including the Recoverable Items folder) reaches 90 GB, it's converted to an auto-expanding archive, and Office 365 adds storage space to the archive. Note that it can take up to 30 days for the additional storage space to be provisioned.
+
+> [!NOTE]
+> If a mailbox is placed on hold or assigned to an Office 365 retention policy, the storage quota for the archive maibox is increased to 110 GB when auto-expanding archiving is enabled. Similarly, the archive warning quota is increased to 100 GB.
     
-3. Office 365 automatically adds more storage space upto 1 TB in size or 20 auxiliary archives when necessary.
+3. Office 365 automatically adds more storage space when necessary. As previously stated, Office 365 will add up to 20 auxiliary archives, for a maximum of 1 TB of additional archive storage space.
   
 > [!IMPORTANT]
-> Auto-expanding archive is only supported for mailboxes used for individual users or shared mailboxes with a growth rate that does not exceed 1 GB per day. Using journaling, transport rules, or auto-forwarding rules to copy messages to an archive mailbox is not permitted. A user's archive mailbox is intended for just that user. Microsoft reserves the right to deny unlimited archiving in instances where a user's archive mailbox is used to store archive data for other users.
-
-> If a mailbox is placed on hold or assigned to an Office 365 retention policy, the storage quota for the archive maibox is increased to 110 GB when auto-expanding archiving is enabled. Similarly, the archive warning quota is increased to 100 GB.
+> Auto-expanding archive is only supported for mailboxes used for individual users (or shared mailboxes) with a growth rate that doesn't exceed 1 GB per day. A user's archive mailbox is intended for just that user. Using journaling, transport rules, or auto-forwarding rules to copy messages to an archive mailbox is not permitted. Microsoft reserves the right to deny unlimited archiving in instances where a user's archive mailbox is used to store archive data for other users.
 
 ## What gets moved to the additional archive storage space?
 

--- a/SecurityCompliance/unlimited-archiving.md
+++ b/SecurityCompliance/unlimited-archiving.md
@@ -21,7 +21,7 @@ description: "Learn about auto-expanding archiving in Office 365, which provides
 
 In Office 365, archive mailboxes provide users with additional mailbox storage space. After a user's archive mailbox is enabled, up to 100 GB of additional storage is available. In the past, when the 100 GB storage quota was reached, organizations had to contact Microsoft to request additional storage space for an archive mailbox. That's no longer the case.
 
-The unlimited archiving feature in Office 365 (called *auto-expanding archiving*) provides an unlimited amount of storage in archive mailboxes. Now, when the storage quota in the archive mailbox is reached, Office 365 automatically increases the size of the archive, which means that users won't run out of mailbox storage space and administrators won't have to request additional storage for archive mailboxes.
+The unlimited archiving feature in Office 365 (called *auto-expanding archiving*) provides upto 1 TB of additional storage in archive mailboxes. Now, when the storage quota in the archive mailbox is reached, Office 365 automatically increases the size of the archive, which means that users won't run out of mailbox storage space and administrators won't have to request additional storage for archive mailboxes.
   
 For step-by-step instructions for turning on auto-expanding archiving, see [Enable unlimited archiving in Office 365](enable-unlimited-archiving.md).
   
@@ -30,7 +30,7 @@ For step-by-step instructions for turning on auto-expanding archiving, see [Enab
   
 ## How auto-expanding archiving works
 
-As previously explained, additional mailbox storage space is created when a user's archive mailbox is enabled. When auto-expanding archiving is enabled, Office 365 periodically checks the size of the archive mailbox. When an archive mailbox gets close to its storage limit, Office 365 automatically creates additional storage space for the archive. If the user runs out of this additional storage space, Office 365 adds more storage space to the user's archive. This process happens automatically, which means administrators don't have to request additional archive storage or manage auto-expanding archiving. 
+As previously explained, additional mailbox storage space is created when a user's archive mailbox is enabled. When auto-expanding archiving is enabled, Office 365 periodically checks the size of the archive mailbox. When an archive mailbox gets close to its storage limit, Office 365 automatically creates additional storage space for the archive commonly referred to as the auxiliary archive. If the user runs out of this additional storage space, Office 365 will add upto 20 auxiliary archives to provide addtional storage. This process happens automatically, which means administrators don't have to request additional archive storage or manage auto-expanding archiving. 
   
 Here's a quick overview of the process.
   
@@ -40,9 +40,11 @@ Here's a quick overview of the process.
     
 2. An administrator enables auto-expanding archiving for the mailbox. Then, when the archive mailbox (including the Recoverable Items folder) reaches 90 GB, it's converted to an auto-expanding archive, and Office 365 adds storage space to the archive. Note that it can take up to 30 days for the additional storage space to be provisioned.
     
-3. Office 365 automatically adds more storage space to the archive when necessary.
+3. Office 365 automatically adds more storage space upto 1 TB in size or 20 auxiliary archives when necessary.
   
 > [!IMPORTANT]
+> Auto-expanding archive is only supported for mailboxes used for individual users or shared mailboxes with a growth rate that does not exceed 1 GB per day. Using journaling, transport rules, or auto-forwarding rules to copy messages to an archive mailbox is not permitted. A user's archive mailbox is intended for just that user. Microsoft reserves the right to deny unlimited archiving in instances where a user's archive mailbox is used to store archive data for other users.
+
 > If a mailbox is placed on hold or assigned to an Office 365 retention policy, the storage quota for the archive maibox is increased to 110 GB when auto-expanding archiving is enabled. Similarly, the archive warning quota is increased to 100 GB.
 
 ## What gets moved to the additional archive storage space?


### PR DESCRIPTION
The goal of the changes is to highlight that Unlimited Archive does have limitation. In general, the unlimited archive will be limited to 1 TB of space or 20 Aux Archives. In addition, I added language from the Service Description which status Unlimited archive is only supported for a user's mailbox.