### PR TITLE
Update use-dkim-to-validate-outbound-email.md

### DIFF
--- a/SecurityCompliance/use-dkim-to-validate-outbound-email.md
+++ b/SecurityCompliance/use-dkim-to-validate-outbound-email.md
@@ -82,11 +82,11 @@ Run the following command:
    
     New-DkimSigningConfig -DomainName <domain> -Enabled $false
        
-    Get-DkimSigningConfig -DomainName domain | fl Selector1CNAME, Selector2CNAME
+    Get-DkimSigningConfig -Identity <domain> | fl Selector1CNAME, Selector2CNAME
     
 Create CNAMEs referenced in Get-DkimSigningConfig output
     
-    Set-DkimSigningConfig -DomainName domain -Enabled $true
+    Set-DkimSigningConfig -Identity <domain> -Enabled $true
     
 The CNAME records in your DNS will point to already created A records that exist in DNS on the Microsoft DNS servers for Office 365.
   


### PR DESCRIPTION
DomainName parameter is not valid anymore for Get and Set DkimSigningConfig
https://docs.microsoft.com/en-us/powershell/module/exchange/antispam-antimalware/get-dkimsigningconfig?view=exchange-ps
https://docs.microsoft.com/en-us/powershell/module/exchange/antispam-antimalware/set-dkimsigningconfig?view=exchange-ps
Adding <> to stay consistent.